### PR TITLE
chmod 600 /swap.img

### DIFF
--- a/content/posts/141.md
+++ b/content/posts/141.md
@@ -21,6 +21,7 @@ sudo swapon --show
 # Create/Attach/Resize swap
 sudo swapoff /swap.img
 sudo fallocate -l 8G /swap.img
+sudo chmod 600 /swap.img
 sudo mkswap /swap.img
 sudo swapon /swap.img
 


### PR DESCRIPTION
On some systems fallocate set chmod 644 by default, which would be very bad for a swap.